### PR TITLE
Trim down IHypermediaService interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://dev.azure.com/marlon-hizole/iHeartLinks/_apis/build/status/iHeartLinks.Core.CI?branchName=master)](https://dev.azure.com/marlon-hizole/iHeartLinks/_build/latest?definitionId=13&branchName=master)
 
-**iHeartLinks.Core** is a class library for implementing [HATEOAS](https://en.wikipedia.org/wiki/HATEOAS) in a RESTful API. It is a framework agnostic library that should be implemented and extended in specific frameworks. See [iHeartLinks.AspNetCore](https://github.com/ponki-d-monkey/iHeartLinks.AspNetCore) as an example - an implementation for ASP.NET core applications.
+**iHeartLinks.Core** is a class library for implementing [HATEOAS](https://en.wikipedia.org/wiki/HATEOAS) in a RESTful API. It is a framework agnostic library that should be implemented and extended in a specific framework. See [iHeartLinks.AspNetCore](https://github.com/ponki-d-monkey/iHeartLinks.AspNetCore) as an example - an implementation in ASP.NET core.
 
 ## Installation
 
@@ -14,7 +14,7 @@ PM> Install-Package iHeartLinks.Core
 
 ## Implementation
 
-Once installed, implement the [IHypermediaService](https://github.com/ponki-d-monkey/iHeartLinks.Core/blob/master/src/iHeartLinks.Core/IHypermediaService.cs) interface. It is an interface for retrieving URL's. See the [implementation](https://github.com/ponki-d-monkey/iHeartLinks.AspNetCore/blob/master/src/iHeartLinks.AspNetCore/HypermediaService.cs) for ASP.NET core as a guide.
+Once installed, implement the [IHypermediaService](https://github.com/ponki-d-monkey/iHeartLinks.Core/blob/master/src/iHeartLinks.Core/IHypermediaService.cs) interface. It is an interface for building links. See the [implementation](https://github.com/ponki-d-monkey/iHeartLinks.AspNetCore/blob/master/src/iHeartLinks.AspNetCore/HypermediaService.cs) for ASP.NET core as a guide.
 
 ## Extending
 
@@ -52,15 +52,6 @@ hypermediaService
  .AddSelf(model)
  .AddLink("get", $"https://your.api.com/person/{model.Id}"))
  .Document;
-```
-
-To pass a method name, call the overload.
-
-```csharp
-hypermediaService
-  .AddSelf(model)
-  .AddLink("get", $"https://your.api.com/person/{model.Id}", "GET"))
-  .Document;
 ```
 
 As seen in the example above, adding a link to a property of a class implementing `IHypermediaDocument` is possible. Another possible use of this method is when the property is a collection.

--- a/src/iHeartLinks.Core/HypermediaBuilderExtension.cs
+++ b/src/iHeartLinks.Core/HypermediaBuilderExtension.cs
@@ -19,21 +19,6 @@ namespace iHeartLinks.Core
             return builder;
         }
 
-        public static IHypermediaBuilder<TDocument> AddLink<TDocument>(this IHypermediaBuilder<TDocument> builder, string rel, string href, string method)
-            where TDocument : IHypermediaDocument
-        {
-            if (builder == null)
-            {
-                throw new ArgumentNullException(nameof(builder));
-            }
-
-            var link = new Link(href, method);
-
-            builder.AddLink(rel, link);
-
-            return builder;
-        }
-
         public static IHypermediaBuilder<TDocument> AddLinksToChild<TDocument>(this IHypermediaBuilder<TDocument> builder, Action<TDocument, IHypermediaService> childHandler)
             where TDocument : IHypermediaDocument
         {

--- a/src/iHeartLinks.Core/HypermediaServiceExtension.cs
+++ b/src/iHeartLinks.Core/HypermediaServiceExtension.cs
@@ -19,9 +19,7 @@ namespace iHeartLinks.Core
                 throw new ArgumentNullException(nameof(document));
             }
 
-            var link = new Link(
-                service.GetCurrentUrl(),
-                service.GetCurrentMethod());
+            var link = service.GetLink();
 
             document.AddLink(SelfRel, link);
 

--- a/src/iHeartLinks.Core/IHypermediaService.cs
+++ b/src/iHeartLinks.Core/IHypermediaService.cs
@@ -4,6 +4,6 @@
     {
         Link GetLink();
 
-        Link GetLink(string key, object args);
+        Link GetLink(string request, object args);
     }
 }

--- a/src/iHeartLinks.Core/IHypermediaService.cs
+++ b/src/iHeartLinks.Core/IHypermediaService.cs
@@ -2,18 +2,8 @@
 {
     public interface IHypermediaService
     {
-        string GetCurrentUrl();
+        Link GetLink();
 
-        string GetUrl(string key);
-
-        string GetUrl(string key, object args);
-
-        string GetCurrentUrlTemplate();
-
-        string GetUrlTemplate(string key);
-
-        string GetCurrentMethod();
-
-        string GetMethod(string key);
+        Link GetLink(string key, object args);
     }
 }

--- a/src/iHeartLinks.Core/Link.cs
+++ b/src/iHeartLinks.Core/Link.cs
@@ -5,20 +5,10 @@ namespace iHeartLinks.Core
     public class Link
     {
         public Link(string href)
-            : this(href, null)
-        {
-        }
-
-        public Link(string href, string method)
         {
             Href = !string.IsNullOrWhiteSpace(href) ? href : throw new ArgumentException($"Parameter '{nameof(href)}' must not be null or empty.");
-            Method = method;
         }
 
         public string Href { get; }
-        
-        public string Method { get; }
-
-        public bool? Templated { get; set; }
     }
 }

--- a/tests/iHeartLinks.Core.Tests/HypermediaBuilderExtensionTests.cs
+++ b/tests/iHeartLinks.Core.Tests/HypermediaBuilderExtensionTests.cs
@@ -9,7 +9,6 @@ namespace iHeartLinks.Core.Tests
     {
         private const string TestRel = "link";
         private const string TestHref = "https://iheartlinks.example.com";
-        private const string TestMethod = "GET";
 
         private readonly Mock<IHypermediaBuilder<IHypermediaDocument>> mockSut;
         private readonly IHypermediaBuilder<IHypermediaDocument> sut;
@@ -38,7 +37,7 @@ namespace iHeartLinks.Core.Tests
             mockSut.Verify(x => 
                 x.AddLink(
                     It.Is<string>(y => y == TestRel), 
-                    It.Is<Link>(y => y.Href == TestHref && y.Method == null)), 
+                    It.Is<Link>(y => y.Href == TestHref)), 
                 Times.Once);
         }
 
@@ -46,36 +45,6 @@ namespace iHeartLinks.Core.Tests
         public void AddLinkShouldReturnSameInstanceOfHypermediaBuilder()
         {
             var result = sut.AddLink(TestRel, TestHref);
-
-            result.Should().BeSameAs(sut);
-        }
-
-        [Fact]
-        public void AddLinkWithMethodShouldThrowArgumentNullExceptionWhenBuilderIsNull()
-        {
-            Func<IHypermediaBuilder<IHypermediaDocument>> func = () => default(IHypermediaBuilder<IHypermediaDocument>).AddLink(TestRel, TestHref, TestMethod);
-
-            func.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("builder");
-
-            mockSut.Verify(x => x.AddLink(It.IsAny<string>(), It.IsAny<Link>()), Times.Never);
-        }
-
-        [Fact]
-        public void AddLinkWithMethodShouldInvokeHypermediaBuilderAddLinkMethod()
-        {
-            sut.AddLink(TestRel, TestHref, TestMethod);
-
-            mockSut.Verify(x =>
-                x.AddLink(
-                    It.Is<string>(y => y == TestRel),
-                    It.Is<Link>(y => y.Href == TestHref && y.Method == TestMethod)),
-                Times.Once);
-        }
-
-        [Fact]
-        public void AddLinkWithMethodShouldReturnSameInstanceOfHypermediaBuilder()
-        {
-            var result = sut.AddLink(TestRel, TestHref, TestMethod);
 
             result.Should().BeSameAs(sut);
         }
@@ -200,7 +169,7 @@ namespace iHeartLinks.Core.Tests
             mockSut.Verify(x =>
                 x.AddLink(
                     It.Is<string>(y => y == TestRel),
-                    It.Is<Link>(y => y.Href == TestHref && y.Method == null)),
+                    It.Is<Link>(y => y.Href == TestHref)),
                 Times.Once);
 
             void HandleBuilder(IHypermediaBuilder<IHypermediaDocument> builder)

--- a/tests/iHeartLinks.Core.Tests/HypermediaServiceExtensionTests.cs
+++ b/tests/iHeartLinks.Core.Tests/HypermediaServiceExtensionTests.cs
@@ -8,7 +8,6 @@ namespace iHeartLinks.Core.Tests
     public sealed class HypermediaServiceExtensionTests
     {
         private const string TestHref = "https://iheartlinks.example.com";
-        private const string TestMethod = "GET";
 
         private readonly Mock<IHypermediaDocument> mockDocument;
         private readonly Mock<IHypermediaService> mockSut;
@@ -19,8 +18,7 @@ namespace iHeartLinks.Core.Tests
             mockDocument = new Mock<IHypermediaDocument>();
 
             mockSut = new Mock<IHypermediaService>();
-            mockSut.Setup(x => x.GetCurrentUrl()).Returns(TestHref);
-            mockSut.Setup(x => x.GetCurrentMethod()).Returns(TestMethod);
+            mockSut.Setup(x => x.GetLink()).Returns(new Link(TestHref));
 
             sut = mockSut.Object;
         }
@@ -32,8 +30,7 @@ namespace iHeartLinks.Core.Tests
 
             func.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("service");
 
-            mockSut.Verify(x => x.GetCurrentUrl(), Times.Never);
-            mockSut.Verify(x => x.GetCurrentMethod(), Times.Never);
+            mockSut.Verify(x => x.GetLink(), Times.Never);
 
             mockDocument.Verify(x => x.AddLink(It.IsAny<string>(), It.IsAny<Link>()), Times.Never);
         }
@@ -45,26 +42,17 @@ namespace iHeartLinks.Core.Tests
 
             func.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("document");
 
-            mockSut.Verify(x => x.GetCurrentUrl(), Times.Never);
-            mockSut.Verify(x => x.GetCurrentMethod(), Times.Never);
+            mockSut.Verify(x => x.GetLink(), Times.Never);
 
             mockDocument.Verify(x => x.AddLink(It.IsAny<string>(), It.IsAny<Link>()), Times.Never);
         }
 
         [Fact]
-        public void AddSelfShouldInvokeHypermediaServiceGetCurrentUrlMethod()
+        public void AddSelfShouldInvokeHypermediaServiceGetLinkMethod()
         {
             sut.AddSelf(mockDocument.Object);
 
-            mockSut.Verify(x => x.GetCurrentUrl(), Times.Once);
-        }
-
-        [Fact]
-        public void AddSelfShouldInvokeHypermediaServiceGetCurrentMethodMethod()
-        {
-            sut.AddSelf(mockDocument.Object);
-
-            mockSut.Verify(x => x.GetCurrentMethod(), Times.Once);
+            mockSut.Verify(x => x.GetLink(), Times.Once);
         }
 
         [Fact]
@@ -75,7 +63,7 @@ namespace iHeartLinks.Core.Tests
             mockDocument.Verify(x =>
                 x.AddLink(
                     It.Is<string>(y => y == "self"),
-                    It.Is<Link>(y => y.Href == TestHref && y.Method == TestMethod)),
+                    It.Is<Link>(y => y.Href == TestHref)),
                 Times.Once);
         }
 

--- a/tests/iHeartLinks.Core.Tests/LinkTests.cs
+++ b/tests/iHeartLinks.Core.Tests/LinkTests.cs
@@ -13,18 +13,6 @@ namespace iHeartLinks.Core.Tests
             var link = new Link(href);
 
             link.Href.Should().Be(href);
-            link.Method.Should().BeNull();
-        }
-
-        [Fact]
-        public void CtorShouldInstantiateObjectWithMethod()
-        {
-            var href = "https://iheartlinks.example.com";
-            var method = "GET";
-            var link = new Link(href, method);
-
-            link.Href.Should().Be(href);
-            link.Method.Should().Be(method);
         }
 
         [Theory]
@@ -34,19 +22,6 @@ namespace iHeartLinks.Core.Tests
         public void CtorShouldThrowArgumentExceptionWhen(string href)
         {
             Action action = () => new Link(href);
-
-            var exception = action.Should().Throw<ArgumentException>().Which;
-            exception.Message.Should().Be("Parameter 'href' must not be null or empty.");
-            exception.ParamName.Should().BeNull();
-        }
-
-        [Theory]
-        [InlineData(null, "GET")]
-        [InlineData("", "GET")]
-        [InlineData(" ", "GET")]
-        public void CtorWithMethodShouldThrowArgumentExceptionWhen(string href, string method)
-        {
-            Action action = () => new Link(href, method);
 
             var exception = action.Should().Throw<ArgumentException>().Which;
             exception.Message.Should().Be("Parameter 'href' must not be null or empty.");


### PR DESCRIPTION
- Remove anything related to HTTP methods
- Remove anything related to templated URL's
- Make IHypermediaService methods return a Link object instead of string.